### PR TITLE
Add Vite-based React frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Node modules
+frontend/node_modules/
+
+# Vite build output
+frontend/dist/

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,18 @@
+# Frontend React App
+
+This folder contains a small React project created with [Vite](https://vitejs.dev/). The app allows you to send four parameters to a backend Python API via a POST request and displays the response.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+   The app will be available at `http://localhost:5173` by default.
+3. Ensure your Python API is running locally (default URL is `http://localhost:5000/api`). If your API runs elsewhere, edit the fetch URL in `src/App.jsx`.
+
+To create a production build, run `npm run build`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React API Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+
+export default function App() {
+  const [params, setParams] = useState({ a: '', b: '', c: '', d: '' });
+  const [result, setResult] = useState('');
+  const [error, setError] = useState('');
+
+  const handleChange = e => {
+    const { name, value } = e.target;
+    setParams(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    setResult('');
+    setError('');
+    try {
+      const response = await fetch('http://localhost:5000/api', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(params)
+      });
+      if (!response.ok) {
+        throw new Error(`Server responded with ${response.status}`);
+      }
+      const data = await response.json();
+      setResult(JSON.stringify(data));
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div>
+      <h1>API Request</h1>
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', width: 300, gap: 8 }}>
+        <label>
+          Param A:
+          <input name="a" value={params.a} onChange={handleChange} />
+        </label>
+        <label>
+          Param B:
+          <input name="b" value={params.b} onChange={handleChange} />
+        </label>
+        <label>
+          Param C:
+          <input name="c" value={params.c} onChange={handleChange} />
+        </label>
+        <label>
+          Param D:
+          <input name="d" value={params.d} onChange={handleChange} />
+        </label>
+        <button type="submit">Submit</button>
+      </form>
+      {result && <pre style={{ marginTop: 20 }}>{result}</pre>}
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()]
+});


### PR DESCRIPTION
## Summary
- replace static HTML with an actual React project using Vite
- add basic React component in `src/App.jsx` to send POST request
- document setup and development commands
- ignore node_modules and build output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878f1e29a7c832ab599ff7b398ca058